### PR TITLE
Randomize S3 bucket names - to prevent collisions and deployment failures for non-unique env-names

### DIFF
--- a/amplify/backend/storage/jamstackcms/s3-cloudformation-template.json
+++ b/amplify/backend/storage/jamstackcms/s3-cloudformation-template.json
@@ -208,6 +208,19 @@
                                     {
                                         "Ref": "bucketName"
                                     },
+                                    {
+                                       "Fn::Select": [
+                                          3,
+                                          {
+                                              "Fn::Split": [
+                                                  "-",
+                                                  {
+                                                      "Ref": "AWS::StackId"
+                                                  }
+                                              ]
+                                          }
+                                        ]
+                                    },
                                     "-",
                                     {
                                         "Ref": "env"
@@ -761,6 +774,19 @@
                                             [
                                                 {
                                                     "Ref": "bucketName"
+                                                },
+                                                {
+                                                   "Fn::Select": [
+                                                      3,
+                                                      {
+                                                          "Fn::Split": [
+                                                              "-",
+                                                              {
+                                                                  "Ref": "AWS::StackId"
+                                                              }
+                                                          ]
+                                                      }
+                                                    ]
                                                 },
                                                 "-",
                                                 {


### PR DESCRIPTION


Added a randomizer - based upon the deployed Cloudformation stack in the S3 bucket name - to prevent collisions in bucket names - since they need to be globally unique.