### PR TITLE
Update AWS Lambda runtime from 8.10 or 10.x to 12.x

### DIFF
--- a/amplify/backend/auth/jamstackcmsc9ee2ce6/jamstackcmsc9ee2ce6-cloudformation-template.yml
+++ b/amplify/backend/auth/jamstackcmsc9ee2ce6/jamstackcmsc9ee2ce6-cloudformation-template.yml
@@ -322,7 +322,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/function/S3Trigger56ef6c3f/S3Trigger56ef6c3f-cloudformation-template.json
+++ b/amplify/backend/function/S3Trigger56ef6c3f/S3Trigger56ef6c3f-cloudformation-template.json
@@ -56,7 +56,7 @@
 						"Arn"
 					]
 				},
-				"Runtime": "nodejs10.x",
+				"Runtime": "nodejs12.x",
 				"Timeout": "300",
 				"MemorySize": 1024,
 				"Code": {

--- a/amplify/backend/function/jamstackcmsc9ee2ce6PostConfirmation/jamstackcmsc9ee2ce6PostConfirmation-cloudformation-template.json
+++ b/amplify/backend/function/jamstackcmsc9ee2ce6PostConfirmation/jamstackcmsc9ee2ce6PostConfirmation-cloudformation-template.json
@@ -98,7 +98,7 @@
 						"Arn"
 					]
 				},
-				"Runtime": "nodejs8.10",
+				"Runtime": "nodejs12.x",
 				"Timeout": "25",
 				"Code": {
 					"S3Bucket": "amplify-jamstack-cms-dev-160039-deployment",


### PR DESCRIPTION
Try to spin this up today and this was the only hurdle during setup. I figure to make AWS Lambda nodejs runtime to `12.x`.